### PR TITLE
Migrate Windows Junction Dependency to Published Crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security testing**: Comprehensive fuzz tests for security invariants (1000+ iterations)
 - **CI workflows**: Kani verification and semver compatibility checks
 
+### Changed
+- **Windows junction dependency**: Switched from `junction` to the `junction-verbatim` git fork crate
+  - `junction-verbatim` is a fork published to crates.io, for use until PR tesuji/junction#31 is merged and published. 
+  - Fixes tesuji/junction#30 (verbatim prefix handling bug)
+  - Enables crates.io publishing (git deps not allowed on registry)
+
 ### Documentation
 - **README badges**: Added Kani Verified and Protected CVEs badges
 - **Security guidance**: Enhanced documentation on `interop_path()` risks in user-facing contexts

--- a/strict-path/Cargo.toml
+++ b/strict-path/Cargo.toml
@@ -28,22 +28,21 @@ dirs = "6.0.0"
 app-path = "1.1.2"
 
 # Windows test helper: junctions for symlink tests when admin privileges unavailable
-# Using DK26 fork which fixes tesuji/junction#30 (verbatim prefix handling)
-# TODO: Switch back to upstream `junction = "1.4"` after tesuji/junction#31 is merged
+# Using junction-verbatim (DK26 fork published to crates.io) which fixes junction#30 (verbatim prefix handling)
 [target.'cfg(windows)'.dev-dependencies]
-junction = { git = "https://github.com/DK26/junction" }
+junction-verbatim = "1.3.0"
 
 # Optional Windows junction support for the library API
-# TODO: Switch back to upstream `junction = "1.4"` after tesuji/junction#31 is merged
+# Using junction-verbatim (DK26 fork published to crates.io) which fixes junction#30 (verbatim prefix handling)
 [target.'cfg(windows)'.dependencies]
-junction = { git = "https://github.com/DK26/junction", optional = true }
+junction-verbatim = { version = "1.3.0", optional = true }
 
 [features]
 # Opt-in virtual filesystem support (VirtualRoot, VirtualPath)
 default = []
 virtual-path = []
-# Windows-only: enable built-in junction creation helpers using the `junction` crate
-junctions = ["dep:junction"]
+# Windows-only: enable built-in junction creation helpers using the `junction-verbatim` crate
+junctions = ["dep:junction-verbatim"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }

--- a/strict-path/src/path/strict_path.rs
+++ b/strict-path/src/path/strict_path.rs
@@ -914,7 +914,7 @@ impl<Marker> StrictPath<Marker> {
         let target_path = strip_verbatim_prefix(self.path());
         let link_path = strip_verbatim_prefix(validated_link.path());
 
-        junction::create(target_path.as_ref(), link_path.as_ref())
+        junction_verbatim::create(target_path.as_ref(), link_path.as_ref())
     }
 
     /// SUMMARY:

--- a/strict-path/src/path/tests/security.rs
+++ b/strict-path/src/path/tests/security.rs
@@ -1412,7 +1412,7 @@ fn test_append_through_junction_escape_is_blocked() {
 
     // Create junction inside boundary pointing to outside directory
     let junction_inside = restriction_dir.join("escape");
-    junction::create(&outside_dir, &junction_inside).expect("junction creation");
+    junction_verbatim::create(&outside_dir, &junction_inside).expect("junction creation");
 
     let boundary: PathBoundary = PathBoundary::try_new(&restriction_dir).unwrap();
 

--- a/strict-path/src/path/tests/symlink_methods.rs
+++ b/strict-path/src/path/tests/symlink_methods.rs
@@ -273,7 +273,8 @@ fn strictpath_symlink_metadata_reports_link_entry() {
                 dir_target.create_dir_all().unwrap();
                 let dir_link = boundary.strict_join("links/junc").unwrap();
                 dir_link.create_parent_dir_all().unwrap();
-                junction::create(dir_target.interop_path(), dir_link.interop_path()).unwrap();
+                junction_verbatim::create(dir_target.interop_path(), dir_link.interop_path())
+                    .unwrap();
                 assert!(dir_link.symlink_metadata().is_ok());
                 assert!(dir_link.metadata().is_ok());
             }
@@ -337,7 +338,8 @@ fn virtualpath_symlink_metadata_reports_link_entry() {
                 strict_target.create_dir_all().unwrap();
                 let strict_link = boundary.strict_join("links/junc").unwrap();
                 strict_link.create_parent_dir_all().unwrap();
-                junction::create(strict_target.interop_path(), strict_link.interop_path()).unwrap();
+                junction_verbatim::create(strict_target.interop_path(), strict_link.interop_path())
+                    .unwrap();
 
                 // Verify via virtual view using relative path
                 let dir_link = vroot.virtual_join("links/junc").unwrap();

--- a/strict-path/src/path/tests/windows_junction_prefix.rs
+++ b/strict-path/src/path/tests/windows_junction_prefix.rs
@@ -1,8 +1,8 @@
 //! Tests for Windows junction prefix mismatch handling
 //!
 //! This module tests junction handling with the updated dependencies:
-//! - DK26/junction fork: fixes tesuji/junction#30 (verbatim prefix handling)
-//! - DK26/soft-canonicalize dev branch: component-aware prefix comparison
+//! - junction-verbatim: DK26 fork published to crates.io, fixes tesuji/junction#30 (verbatim prefix handling)
+//! - soft-canonicalize 0.5.3: component-aware prefix comparison
 //!
 //! Issue background:
 //! 1. Junction crate bug: Passing verbatim paths (`\\?\C:\...`) to `junction::create()`
@@ -146,7 +146,7 @@ fn test_junction_creation_with_verbatim_target() {
     // Create junction using canonicalized (verbatim) target
     // This would FAIL with junction 1.3, but should WORK with DK26 fork
     let junction_path = td.path().join("test_junction");
-    if let Err(e) = junction::create(&canonical_target, &junction_path) {
+    if let Err(e) = junction_verbatim::create(&canonical_target, &junction_path) {
         panic!("Junction creation with verbatim target failed (DK26 fork should fix this): {e:?}");
     }
 
@@ -185,7 +185,8 @@ fn test_soft_canonicalize_handles_junction_prefix_mismatch() {
     std::fs::create_dir_all(anchor.join("real_data")).unwrap();
 
     // Create junction (junction targets are stored as non-verbatim internally by Windows)
-    if let Err(e) = junction::create(anchor.join("real_data"), anchor.join("link_to_data")) {
+    if let Err(e) = junction_verbatim::create(anchor.join("real_data"), anchor.join("link_to_data"))
+    {
         eprintln!("Skipping test: failed to create junction: {e:?}");
         return;
     }


### PR DESCRIPTION
# Migrate Windows Junction Dependency to Published Crate

Replace git fork `junction` with published `junction-verbatim` crate (v1.3.0) to enable crates.io publishing.

## What Changed

- Replaced `junction = { git = "..." }` with `junction-verbatim = "1.3.0"` in Cargo.toml (both dev and optional deps)
- Updated feature definition: `junctions = ["dep:junction-verbatim"]`
- Replaced all `junction::create()` calls with `junction_verbatim::create()` across 4 test files
- Updated CHANGELOG.md with migration notes

## Why

crates.io publishing requires all dependencies to have version requirements. Git dependencies are not permitted.

## Testing

- ✅ All 202 library tests pass
- ✅ `cargo publish --dry-run` succeeds (was previously blocked)
- ✅ No functional changes - API is identical

Ready to merge and publish.
