### PR TITLE
Release v0.2.1 — Security audit fixes (F1–F7) + upstream dependency hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Cargo.toml keywords updated (`filesystem` → `sanitization`).
 
+### Dependencies
+- **`soft-canonicalize` 0.5.5 → 0.5.6** (security):
+  - Fixed `anchored_canonicalize` escape via absolute `..` symlink targets — extracted `normalize_and_clamp_to_anchor` so every clamp site uses the same logic.
+  - NUL-byte detection now always path-aware — `soft_canon_detail()` consistently returns `"path contains null byte"` instead of stdlib's generic `InvalidInput`.
+  - Forward-slash UNC rejection — `is_incomplete_unc` now detects `//server` and mixed-separator variants.
+  - Windows: `simple_normalize_path` preserves `VerbatimDisk` prefix (previously silently dropped it, breaking anchored clamp checks).
+  - Windows: Fixed `anchored_canonicalize` `..` pop skipped on `Disk` vs `VerbatimDisk` prefix mismatch.
+- **`proc-canonicalize` 0.1.2 → 0.1.3** (transitive via `soft-canonicalize`; security):
+  - Fixed namespace-boundary bypass via `..` in PID prefix — paths like `/proc/<PID>/../<PID>/root` previously evaded detection and returned `/`, silently dropping the namespace boundary. Scanner now lexically normalizes before boundary detection.
+  - Performance: eliminated per-iteration heap allocations in the indirect-symlink scanner.
+
 ### Documentation
 - README: "Zero Idle Dependencies" section documenting the security role of every runtime dependency.
 - README: Canonicalization-vs-blocklists rationale expanded.


### PR DESCRIPTION
# Release v0.2.1 — Security audit fixes (F1–F7) + upstream dependency hardening

## Summary

Patch release addressing 7 findings from a security audit, each with regression tests. Includes upstream security fixes from `soft-canonicalize` 0.5.6 and `proc-canonicalize` 0.1.3. No breaking changes, no MSRV change.

## Security Fixes

| ID | Finding | Severity |
|----|---------|----------|
| F1 | `with_extension` panic DoS on path-separator extensions | Medium |
| F2 | Display sanitizer only covered `\n` and `;` — missing C0/DEL controls | Medium |
| F3 | `strictpath_parent` at boundary root returned escape error instead of `Ok(None)` | Low |
| F4 | `FromStr` for `PathBoundary`/`VirtualRoot` created directories from untrusted input | High |
| F5 | Hand-rolled verbatim prefix stripping lost data on non-UTF-8 paths | Medium |
| F6 | Display sanitizer missed C1 controls, bidi overrides, and line terminators | Medium |
| F7 | Virtual path stored sanitized names, breaking navigation when dirs contain control chars | High |

### F1 — `with_extension` panic DoS
`Path::with_extension` panics on extensions containing path separators. Added `validate_extension()` to reject separators and NUL bytes with `Err` instead of crashing.

### F2 + F6 — Display sanitizer gaps
`sanitize_display_component` now replaces C0 controls, DEL, C1 controls (U+0080–U+009F), ECMAScript line terminators (U+2028/U+2029), Unicode directional overrides/marks (U+202A–U+202E, U+2066–U+2069, U+200E/U+200F), and `;`. Prevents CRLF header splitting, ANSI escape injection, log line spoofing, and bidirectional text attacks.

### F3 — `strictpath_parent` at boundary root
Returned `Err(PathEscapesBoundary)` instead of `Ok(None)`, making fallback arms in `strict_rename`, `strict_copy`, `strict_symlink`, `strict_hard_link`, and `strict_junction` dead code.

### F4 — `FromStr` side effects
`PathBoundary`/`VirtualRoot` `FromStr` called `try_new_create`, letting attacker-controlled strings create arbitrary directories. Changed to `try_new` (validate-only).

### F5 — Verbatim prefix stripping
Replaced hand-rolled `to_string_lossy` + `strip_prefix("\\?\")` with `dunce::simplified`, which pattern-matches `std::path::Prefix` variants without lossy UTF-8 round-trip and refuses to strip when unsafe (reserved names, >MAX_PATH, trailing dots). Also handles `\\.\` prefixes.

### F7 — Virtual path display vs storage mismatch
`compute_virtual` stored sanitized component names in `virtual_path`, causing `virtual_join` and `virtualpath_parent` to navigate to the wrong system path. Moved sanitization from storage time to display time (`VirtualPathDisplay::fmt`).

## Upstream Dependency Hardening

### `soft-canonicalize` 0.5.5 → 0.5.6 (security)
- Fixed `anchored_canonicalize` escape via absolute `..` symlink targets
- NUL-byte detection now always path-aware
- Forward-slash UNC rejection (`//server` and mixed-separator variants)
- Windows: `simple_normalize_path` preserves `VerbatimDisk` prefix
- Windows: Fixed `anchored_canonicalize` `..` pop skipped on `Disk` vs `VerbatimDisk` mismatch

### `proc-canonicalize` 0.1.2 → 0.1.3 (transitive; security)
- Fixed namespace-boundary bypass via `..` in PID prefix (`/proc/<PID>/../<PID>/root` evaded detection and returned `/`)
- Eliminated per-iteration heap allocations in indirect-symlink scanner

## Other Changes

### Added
- `dunce` 1.0 as a Windows-only runtime dependency (zero transitive deps)
- Regression tests for all 7 audit findings (`security_audit_findings.rs`, `_f6.rs`, `_f7.rs`)
- `security_canonicalization_proof.rs` — 337-line proof covering overlong UTF-8, URL encoding, HTML entities, Unicode homoglyphs, protocol schemes, whitespace injection, tilde/env-var expansion, and multi-layer combinations
- Fuzz tests for `with_extension` (1000 iterations per path type)
- `#[doc(alias)]` on all four core types for common search terms
- Kani verification scope note

### Changed
- Cargo.toml keywords: `filesystem` → `sanitization`

### Documentation
- README: "Zero Idle Dependencies" section documenting the security role of every runtime dependency
- README: Canonicalization-vs-blocklists rationale expanded
- Fixed no-`AsRef`/`Deref` bullet to name the actual threat (`.join()`)

## Stats

- **20 files changed**, +2,685 / −1,454 lines
- **4 commits** since v0.2.0
- No breaking changes, no MSRV change