### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Error display sanitizer**: `StrictPathError` Display now scrubs the same
+  injection characters as `virtualpath_display()` from path text and
+  `io::Error` source strings before they enter error messages: C0/C1 controls,
+  DEL, U+2028/U+2029, Unicode directional overrides/marks, and `;`. The
+  sanitizer is now shared via `crate::sanitize`.
+
 ## [0.2.2] - 2026-04-22
 
 ### Reverted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-05-02
+
 ### Fixed
 - **Error display sanitizer**: `StrictPathError` Display now scrubs the same
   injection characters as `virtualpath_display()` from path text and
   `io::Error` source strings before they enter error messages: C0/C1 controls,
   DEL, U+2028/U+2029, Unicode directional overrides/marks, and `;`. The
   sanitizer is now shared via `crate::sanitize`.
+
+### Documentation
+- README clarified how canonicalization/path resolution and boundary checks
+  interact.
+- README expanded guidance on `PathBoundary` usage, limitations, and what the
+  crate guarantees.
 
 ## [0.2.2] - 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You strip `..` and check for `/`. But attackers have a dozen other vectors:
 | Null byte injection | ❌ Truncation varies | ✅ Blocked |
 | Mixed separators: `..\../etc` | ❌ Often missed | ✅ Normalized & blocked |
 
-**How it works:** `strict-path` resolves the path on disk — follows symlinks, expands short names, normalizes encoding — then proves the resolved path is inside the boundary. The input string is irrelevant. Only where the path *actually leads* matters.
+**How it works:** `strict-path` resolves the path on disk — follows symlinks, expands short names, normalizes encoding — then checks whether the resolved path is inside the boundary. If it isn't, you get an `Err`. The input string is irrelevant. Only where the path *actually leads* matters.
 
 <details>
 <summary><strong>Why canonicalization beats string blocklists</strong></summary>
@@ -104,7 +104,7 @@ If the input resolves outside the boundary — by *any* mechanism — `strict_jo
 
 ### Archive Extraction (Zip Slip Prevention)
 
-Take `PathBoundary` as a function parameter when the boundary is reused — every `strict_join` on it produces a `StrictPath` pinned inside that directory, so the function body doesn't have to re-validate.
+`PathBoundary` in the signature names the legal boundary for this operation — the directory that joined paths must stay inside.
 
 ```rust
 use strict_path::PathBoundary;
@@ -144,7 +144,7 @@ fn handle_file_request(tenant_id: &str, requested_path: &str) -> std::io::Result
 
 ## 🧠 Compile-Time Safety with Markers
 
-`StrictPath<Marker>` enables **domain separation and authorization** at compile time — handing a user-uploaded file to a function that only accepts public assets is a compile error, not a runtime check:
+Tag a `StrictPath` with a marker type so a function can only accept paths from the boundary you meant. Mixing them up is a compile error:
 
 ```rust
 use strict_path::{PathBoundary, StrictPath};
@@ -180,11 +180,11 @@ serve_public_asset(&css);       // ✅ OK — PublicAssets matches
 
 This crate combines Rust's type system with Python's "one obvious way to do it" philosophy to build an API where **LLMs and humans naturally reach for the correct pattern** — wrong code either doesn't compile, or the compiler tells you exactly what to do instead.
 
-- **No `AsRef<Path>`, no `Deref`** — if `StrictPath` implemented these, anything could call `.join()` on it and build a new path that bypasses boundary validation entirely. That one method on `Path` undoes everything `strict_join()` enforces. The type system makes it unreachable.
-- **`interop_path()` returns `&OsStr`, not `&Path`** — `Path` has `.join()` and `.parent()`, which let you build new unvalidated paths. `OsStr` has none of that — it's a one-way exit to third-party crates with no way to accidentally re-enter path manipulation.
-- **One method per operation** — every operation has exactly one method. An LLM scanning the API can't pick the wrong overload because there isn't one. No aliases, no convenience wrappers, no "which one is the secure version?" Even the weakest model gets it right on the first try.
-- **`#[must_use]` with instructions, not just warnings** — the compiler becomes the documentation. When an LLM generates code and forgets to handle a `strict_join()` result, it doesn't get a generic "unused Result" — it gets a message like *"always handle the Result to detect path traversal attacks"*. The LLM reads the compiler output, self-corrects, and gets it right on the next pass. No docs lookup needed.
-- **Doc comments explain *why*, not just *what*** — every non-trivial function documents the reasoning behind the code, what attack a check prevents, or what invariant it enforces. An LLM working with just the source file can reason about design intent without any external context.
+- **No `AsRef<Path>`, no `Deref`** — implementing either would let anything call `.join()` on a `StrictPath` and build a new path that skips boundary validation. Not implementing them closes that accidental path.
+- **`interop_path()` returns `&OsStr`, not `&Path`** — `&Path` carries `.join()` and `.parent()`, which would let callers build new unvalidated paths from a validated one. `&OsStr` doesn't; it's a one-way exit to third-party APIs with no accidental re-entry into path manipulation.
+- **One method per operation** — there is a single entry point for each operation (e.g. `strict_join` for joining). No aliases, no convenience wrappers, no "which one is the secure version?". The wrong-overload failure mode doesn't exist because there are no overloads.
+- **`#[must_use]` with instructions** — the `must_use` messages don't just say "unused Result", they say what to do (e.g. handle the result to detect traversal). When a caller — human or model — loops on compiler output, the message itself teaches the API.
+- **Doc comments explain *why*, not just *what*** — non-trivial functions document what attack the check prevents or what invariant it enforces, so a reader working from source alone has the reasoning on hand.
 
 </details>
 
@@ -192,7 +192,7 @@ This crate combines Rust's type system with Python's "one obvious way to do it" 
 
 ## 🔒 Zero Idle Dependencies
 
-Every runtime dependency exists to close a specific security gap. Each is audited, tested against attack payloads, and covered by `cargo audit` in CI.
+Every dependency in the default tree earns its place by closing a specific gap in cross-platform path resolution. Each is covered by `cargo audit` in CI, and the canonicalization engine has direct tests against the CVE payloads listed above.
 
 | Crate | Platforms | Security role |
 |---|---|---|
@@ -205,8 +205,8 @@ On Unix the total runtime tree is **2 crates** (`soft-canonicalize` + `proc-cano
 <details>
 <summary><strong>vs manual <code>soft-canonicalize</code></strong></summary>
 
-- `soft-canonicalize` = low-level path resolution engine (returns `PathBuf`)
-- `strict-path` = high-level security API (returns `StrictPath<Marker>` with compile-time guarantees, fit for the LLM era)
+- `soft-canonicalize` = low-level path resolution engine (returns `PathBuf` — unchecked against a boundary)
+- `strict-path` = higher-level API on top of it: returns `StrictPath<Marker>`, which carries a checked boundary and a compile-time marker so paths from different trust zones can't be passed to the same function by mistake
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@
 [![Security Audit](https://github.com/DK26/strict-path-rs/actions/workflows/audit.yml/badge.svg?branch=main)](https://github.com/DK26/strict-path-rs/actions/workflows/audit.yml)
 [![Kani Verified](https://github.com/DK26/strict-path-rs/actions/workflows/kani.yml/badge.svg?branch=main)](https://github.com/DK26/strict-path-rs/actions/workflows/kani.yml)
 [![Protected CVEs](https://img.shields.io/badge/protected%20CVEs-19%2B-brightgreen.svg)](https://github.com/DK26/strict-path-rs/blob/main/strict-path/src/path/tests/cve_2025_11001.rs)
+[![MSRV 1.76](https://img.shields.io/badge/MSRV-1.76-orange.svg)](https://github.com/DK26/strict-path-rs/blob/main/strict-path/Cargo.toml)
 [![Type-State Police](https://img.shields.io/badge/protected%20by-Type--State%20Police-blue.svg)](https://github.com/DK26/strict-path-rs)
 
-**Secure path handling for untrusted input.** Paths from users, config files, archives, or AI agents can't escape the directory you put them in — regardless of symlinks, encoding tricks, or platform quirks. [19+ real-world CVEs covered](https://dk26.github.io/strict-path-rs/security_methodology.html#12-coverage-what-we-protect-against).
+**The moment a path string enters your program from outside your code — an HTTP request, a config file, an archive entry, a database row, an LLM tool call — reach for `strict-path`.** It pins that string to a directory you chose, so it can't escape via symlinks, encoding tricks, or platform quirks. [19+ real-world CVEs covered](https://dk26.github.io/strict-path-rs/security_methodology.html#12-coverage-what-we-protect-against).
 
-> Prepared statements prevent SQL injection. `strict-path` prevents path injection.
+> Prepared statements prevent SQL injection. `strict-path` prevents path injection. Same rule: **data from outside never gets to act as structure.**
 
 ## 🔍 Why String Checking Isn't Enough
 
@@ -46,7 +47,7 @@ This is the same principle behind SQL prepared statements: instead of escaping e
 
 ```toml
 [dependencies]
-strict-path = "0.2"  # every dependency closes a security gap — see "Zero Idle Dependencies" below
+strict-path = "0.2"
 ```
 
 ```rust
@@ -64,14 +65,30 @@ third_party::process(file.interop_path()); // &OsStr (implements AsRef<Path>)
 
 If the input resolves outside the boundary — by *any* mechanism — `strict_join` returns `Err`.
 
-**What you get beyond path validation:**
+> **Is this overkill for my use case?** If you accept paths from users, config files, archives, databases, or AI agents — no, this is the minimum.
+> If all your paths are hardcoded constants — use `std::path`. See [choosing canonicalized vs lexical](https://dk26.github.io/strict-path-rs/ergonomics/choosing_canonicalized_vs_lexical_solution.html).
+
+## 🎯 What It Is *Not*
+
+- Not a sandbox or chroot — your process still has whatever filesystem access the OS grants it.
+- Not a replacement for filesystem permissions, SELinux/AppArmor, or `openat2(RESOLVE_BENEATH)`. Compose with those where you have them.
+- Not a URL or shell-argument sanitizer — different injection class, different tool.
+- Not a performance-tuned lexical normalizer — canonicalization touches the disk. If your paths are hardcoded constants and you need nanoseconds, use `std::path` instead.
+
+> 📖 **New to strict-path?** Start with the **[Tutorial: Chapter 1 — The Basic Promise →](https://dk26.github.io/strict-path-rs/tutorial/chapter1_basic_promise.html)**
+
+## 🧰 What You Get Beyond Path Validation
+
 - 🛡️ **Built-in I/O** — `read()`, `write()`, `create_dir_all()`, `read_dir()` — no need to drop to `std::fs`
 - 📐 **Compile-time markers** — `StrictPath<UserUploads>` vs `StrictPath<SystemConfig>` can't be mixed up
 - ⚡ **Dual modes** — `StrictPath` (detect & reject escapes) or `VirtualPath` (clamp & contain)
 - 🔒 **Thread-safe** — all types are `Send + Sync`; share across threads and async tasks
 - 🤖 **LLM-ready** — doc comments and [context files](https://github.com/DK26/strict-path-rs/blob/main/LLM_CONTEXT_FULL.md) designed for AI agents with function calling
 
-**Why the API looks the way it does:**
+<details>
+<summary><strong>Why the API looks the way it does (design notes for security reviewers and LLM integrators)</strong></summary>
+
+<br>
 
 This crate combines Rust's type system with Python's "one obvious way to do it" philosophy to build an API where **LLMs and humans naturally reach for the correct pattern** — wrong code either doesn't compile, or the compiler tells you exactly what to do instead.
 
@@ -80,63 +97,37 @@ This crate combines Rust's type system with Python's "one obvious way to do it" 
 - **One method per operation** — every operation has exactly one method. An LLM scanning the API can't pick the wrong overload because there isn't one. No aliases, no convenience wrappers, no "which one is the secure version?" Even the weakest model gets it right on the first try.
 - **`#[must_use]` with instructions, not just warnings** — the compiler becomes the documentation. When an LLM generates code and forgets to handle a `strict_join()` result, it doesn't get a generic "unused Result" — it gets a message like *"always handle the Result to detect path traversal attacks"*. The LLM reads the compiler output, self-corrects, and gets it right on the next pass. No docs lookup needed.
 - **Doc comments explain *why*, not just *what*** — every non-trivial function documents the reasoning behind the code, what attack a check prevents, or what invariant it enforces. An LLM working with just the source file can reason about design intent without any external context.
-- **[Context7](https://github.com/DK26/strict-path-rs/blob/main/LLM_CONTEXT.md) and [LLM context files](https://github.com/DK26/strict-path-rs/blob/main/LLM_CONTEXT_FULL.md)** — machine-readable API references that ship with the crate, sized for different context windows. Critical mistakes front-loaded so an LLM agent hits the important stuff first.
-
-> **Is this overkill for my use case?** If you accept paths from users, config files, archives, databases, or AI agents — no, this is the minimum.
-> If all your paths are hardcoded constants — use `std::path`. See [choosing canonicalized vs lexical](https://dk26.github.io/strict-path-rs/ergonomics/choosing_canonicalized_vs_lexical_solution.html).
-
-> 📖 **New to strict-path?** Start with the **[Tutorial: Chapter 1 - The Basic Promise →](https://dk26.github.io/strict-path-rs/tutorial/chapter1_basic_promise.html)**
-
-<details>
-<summary>🤖 <strong>LLM / AI Agent Integration</strong></summary>
-
-<br>
-
-Our doc comments and [LLM_CONTEXT_FULL.md](https://github.com/DK26/strict-path-rs/blob/main/LLM_CONTEXT_FULL.md) are designed for LLMs with function calling — enabling AI agents to use this crate safely for file operations.
-
-**LLM agent prompt (copy/paste):**
-``` 
-Fetch and follow this reference (single source of truth):
-https://github.com/DK26/strict-path-rs/blob/main/LLM_CONTEXT_FULL.md
-```
-
-**Context7 style:**
-```
-Fetch and follow this reference (single source of truth):
-https://github.com/DK26/strict-path-rs/blob/main/LLM_CONTEXT.md
-```
 
 </details>
 
 > 📖 **[Security Methodology →](https://dk26.github.io/strict-path-rs/security_methodology.html)** | 📚 **[Built-in I/O Methods →](https://dk26.github.io/strict-path-rs/best_practices/common_operations.html)** | 📚 **[Anti-Patterns →](https://dk26.github.io/strict-path-rs/anti_patterns.html)**
 
-## 🎯 **StrictPath vs VirtualPath: When to Use What**
+## 🎯 When to Use What
 
-### Which type should I use?
+**The trigger is the *origin of the path string*.** Is the string something your code produced, or did it come from outside?
 
-- **Path/PathBuf** (std): When the path comes from a safe source within your control, not external input.
-- **StrictPath**: When you want to restrict paths to a specific boundary and error if they escape.
-- **VirtualPath**: When you want to provide path freedom under isolation.
+- **`Path` / `PathBuf`** (std) — the string is **yours**: a hardcoded constant, or assembled entirely from values your own code produced. There's no external input to validate.
+- **`StrictPath`** — the string came from **outside** (HTTP request, config file, archive entry, DB row, env var, LLM tool call, …) and an escape attempt is an **error** you want to know about. Log it, deny the request, abort the operation. Silently substituting a different file would hide the problem.
+- **`VirtualPath`** — the string came from **outside**, and an escape attempt should be **clamped**. The caller is navigating a sandbox you gave them (their own "/"), and `..` off the top just lands them back at their root.
 
-**Choose StrictPath (90% of cases):**
+**Choose `StrictPath` (≈ 90% of cases):**
 - Archive extraction, config loading
 - File uploads to shared storage (admin panels, CMS assets, single-tenant apps)
-- LLM/AI agent file operations
+- LLM / AI agent file operations
 - Shared system resources (logs, cache, assets)
-- **Any case where escaping a path boundary, is considered malicious**
+- *Any case where escaping a path boundary is considered malicious.*
 
-**Choose VirtualPath (10% of cases):**
-- Multi-tenant file uploads (SaaS per-user storage, isolated user directories)
-- Multi-tenant isolation (per-user filesystem views)
+**Choose `VirtualPath` (≈ 10% of cases):**
+- Multi-tenant file storage (SaaS per-user directories, isolated views)
 - Malware analysis sandboxes
 - Container-like plugins
-- **Any case where you would like to allow freedom of operations under complete isolation**
+- *Any case where you want freedom of operation under complete isolation.*
 
 > 📖 **[Complete Decision Matrix →](https://dk26.github.io/strict-path-rs/best_practices.html)** | 📚 **[More Examples →](https://dk26.github.io/strict-path-rs/examples/overview.html)**
 
 ---
 
-## 🚀 **More Real-World Examples**
+## 🚀 Real-World Examples
 
 ### Archive Extraction (Zip Slip Prevention)
 
@@ -148,8 +139,8 @@ use strict_path::PathBoundary;
 // Prevents CVE-2018-1000178 (Zip Slip) automatically (https://snyk.io/research/zip-slip-vulnerability)
 fn extract_archive(
     extraction_dir: PathBoundary,
-    archive_entries: impl IntoIterator<Item=(String, Vec<u8>)>) -> std::io::Result<()> {
-
+    archive_entries: impl IntoIterator<Item = (String, Vec<u8>)>,
+) -> std::io::Result<()> {
     for (entry_path, data) in archive_entries {
         // Malicious paths like "../../../etc/passwd" → Err(PathEscapesBoundary)
         let safe_file = extraction_dir.strict_join(&entry_path)?;
@@ -160,8 +151,7 @@ fn extract_archive(
 }
 ```
 
-> The equivalent `PathBoundary` for `VirtualPath` type is the `VirtualRoot` type.
-
+> The equivalent of `PathBoundary` for `VirtualPath` is the `VirtualRoot` type.
 
 ### Multi-Tenant Isolation
 
@@ -172,7 +162,7 @@ use strict_path::VirtualRoot;
 // Everything is clamped to the virtual root, including symlink resolutions.
 fn handle_file_request(tenant_id: &str, requested_path: &str) -> std::io::Result<Vec<u8>> {
     let tenant_root = VirtualRoot::try_new_create(format!("./tenants/{tenant_id}"))?;
-    
+
     // "../../other_tenant/secrets.txt" → clamped to "/other_tenant/secrets.txt" in THIS tenant
     let user_file = tenant_root.virtual_join(requested_path)?;
     user_file.read()
@@ -181,12 +171,9 @@ fn handle_file_request(tenant_id: &str, requested_path: &str) -> std::io::Result
 
 ---
 
+## 🧠 Compile-Time Safety with Markers
 
-## 🧠 **Compile-Time Safety with Markers**
-
-`StrictPath<Marker>` enables **domain separation and authorization** at compile time.
-The example below gives a function that only accepts public assets — handing it a
-user-uploaded file is a compile error, not a runtime check:
+`StrictPath<Marker>` enables **domain separation and authorization** at compile time — handing a user-uploaded file to a function that only accepts public assets is a compile error, not a runtime check:
 
 ```rust
 use strict_path::{PathBoundary, StrictPath};
@@ -199,22 +186,18 @@ fn serve_public_asset(file: &StrictPath<PublicAssets>) { /* safe to stream to an
 let assets  = PathBoundary::<PublicAssets>::try_new_create("./assets")?;
 let uploads = PathBoundary::<UserUploads>::try_new_create("./uploads")?;
 
-// Untrusted input from request parameters, form data, database, etc.
-let requested_css   = "style.css";   // From request: /static/style.css
-let uploaded_avatar = "avatar.jpg";  // From form: <input type="file">
-
-let css:    StrictPath<PublicAssets> = assets.strict_join(requested_css)?;
-let avatar: StrictPath<UserUploads>  = uploads.strict_join(uploaded_avatar)?;
+let css:    StrictPath<PublicAssets> = assets.strict_join("style.css")?;
+let avatar: StrictPath<UserUploads>  = uploads.strict_join("avatar.jpg")?;
 
 serve_public_asset(&css);       // ✅ OK — PublicAssets matches
 // serve_public_asset(&avatar); // ❌ Compile error — UserUploads is not PublicAssets
 ```
 
-> 📖 **[Complete Marker Tutorial →](https://dk26.github.io/strict-path-rs/tutorial/chapter3_markers.html)** - Authorization patterns, permission matrices, `change_marker()` usage
+> 📖 **[Complete Marker Tutorial →](https://dk26.github.io/strict-path-rs/tutorial/chapter3_markers.html)** — authorization patterns, permission matrices, `change_marker()` usage.
 
 ---
 
-### 🔒 Zero Idle Dependencies
+## 🔒 Zero Idle Dependencies
 
 Every runtime dependency exists to close a specific security gap. Each is audited, tested against attack payloads, and covered by `cargo audit` in CI.
 
@@ -230,13 +213,13 @@ On Unix the total runtime tree is **2 crates** (`soft-canonicalize` + `proc-cano
 <summary><strong>vs manual <code>soft-canonicalize</code></strong></summary>
 
 - `soft-canonicalize` = low-level path resolution engine (returns `PathBuf`)
-- `strict-path` = high-level security API (returns `StrictPath<Marker>` with compile-time guarantees: fit for LLM era)
+- `strict-path` = high-level security API (returns `StrictPath<Marker>` with compile-time guarantees, fit for the LLM era)
 
 </details>
 
 ---
 
-## 🔌 **Ecosystem Integration**
+## 🔌 Ecosystem Integration
 
 Compose with standard Rust crates for complete solutions:
 
@@ -247,18 +230,41 @@ Compose with standard Rust crates for complete solutions:
 | **app-path** | Application directories | [Guide](https://dk26.github.io/strict-path-rs/ecosystem_integration.html#portable-application-paths-app-path) |
 | **serde**    | Config bootstrap        | [Guide](https://dk26.github.io/strict-path-rs/ecosystem_integration.html#initializing-from-configuration) |
 | **Axum**     | Web server extractors   | [Tutorial](https://dk26.github.io/strict-path-rs/axum_tutorial/overview.html)               |
-| **Archives** | ZIP/TAR extraction      | [Guide](https://dk26.github.io/strict-path-rs/examples/archive_extraction.html)             |
+| **Archives** | ZIP / TAR extraction    | [Guide](https://dk26.github.io/strict-path-rs/examples/archive_extraction.html)             |
 
 > 📚 **[Complete Integration Guide →](https://dk26.github.io/strict-path-rs/ecosystem_integration.html)**
 
 ---
 
-## 📚 **Learn More**
+<details>
+<summary>🤖 <strong>LLM / AI Agent Integration</strong></summary>
 
-📖 **[API Docs](https://docs.rs/strict-path)** | 📚 **[User Guide](https://dk26.github.io/strict-path-rs/)** | 📚 **[Anti-Patterns](https://dk26.github.io/strict-path-rs/anti_patterns.html)** | 📖 **[Security Methodology](https://dk26.github.io/strict-path-rs/security_methodology.html)** | 🧭 **[Canonicalized vs Lexical](https://dk26.github.io/strict-path-rs/ergonomics/choosing_canonicalized_vs_lexical_solution.html)** | 🛠️ **[`soft-canonicalize`](https://github.com/DK26/soft-canonicalize-rs)**
+<br>
+
+Our doc comments and [LLM_CONTEXT_FULL.md](https://github.com/DK26/strict-path-rs/blob/main/LLM_CONTEXT_FULL.md) are designed for LLMs with function calling — enabling AI agents to use this crate safely for file operations.
+
+**LLM agent prompt (copy/paste):**
+```
+Fetch and follow this reference (single source of truth):
+https://github.com/DK26/strict-path-rs/blob/main/LLM_CONTEXT_FULL.md
+```
+
+**Context7 style:**
+```
+Fetch and follow this reference (single source of truth):
+https://github.com/DK26/strict-path-rs/blob/main/LLM_CONTEXT.md
+```
+
+</details>
 
 ---
 
-## 📄 **License**
+## 📚 Learn More
+
+📖 **[API Docs](https://docs.rs/strict-path)** · 📚 **[User Guide](https://dk26.github.io/strict-path-rs/)** · 📚 **[Anti-Patterns](https://dk26.github.io/strict-path-rs/anti_patterns.html)** · 📖 **[Security Methodology](https://dk26.github.io/strict-path-rs/security_methodology.html)** · 🧭 **[Canonicalized vs Lexical](https://dk26.github.io/strict-path-rs/ergonomics/choosing_canonicalized_vs_lexical_solution.html)** · 🛠️ **[`soft-canonicalize`](https://github.com/DK26/soft-canonicalize-rs)**
+
+**MSRV:** Rust 1.76 · **Releases:** [CHANGELOG.md](CHANGELOG.md)
+
+## 📄 License
 
 MIT OR Apache-2.0

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If the input resolves outside the boundary — by *any* mechanism — `strict_jo
 
 ### Archive Extraction (Zip Slip Prevention)
 
-Pass `PathBoundary` by name in the function signature — the type itself proves the caller supplied a vetted directory, and every `strict_join` stays inside it.
+Take `PathBoundary` as a function parameter when the boundary is reused — every `strict_join` on it produces a `StrictPath` pinned inside that directory, so the function body doesn't have to re-validate.
 
 ```rust
 use strict_path::PathBoundary;

--- a/README.md
+++ b/README.md
@@ -65,43 +65,6 @@ third_party::process(file.interop_path()); // &OsStr (implements AsRef<Path>)
 
 If the input resolves outside the boundary — by *any* mechanism — `strict_join` returns `Err`.
 
-> **Is this overkill for my use case?** If you accept paths from users, config files, archives, databases, or AI agents — no, this is the minimum.
-> If all your paths are hardcoded constants — use `std::path`. See [choosing canonicalized vs lexical](https://dk26.github.io/strict-path-rs/ergonomics/choosing_canonicalized_vs_lexical_solution.html).
-
-## 🎯 What It Is *Not*
-
-- Not a sandbox or chroot — your process still has whatever filesystem access the OS grants it.
-- Not a replacement for filesystem permissions, SELinux/AppArmor, or `openat2(RESOLVE_BENEATH)`. Compose with those where you have them.
-- Not a URL or shell-argument sanitizer — different injection class, different tool.
-- Not a performance-tuned lexical normalizer — canonicalization touches the disk. If your paths are hardcoded constants and you need nanoseconds, use `std::path` instead.
-
-> 📖 **New to strict-path?** Start with the **[Tutorial: Chapter 1 — The Basic Promise →](https://dk26.github.io/strict-path-rs/tutorial/chapter1_basic_promise.html)**
-
-## 🧰 What You Get Beyond Path Validation
-
-- 🛡️ **Built-in I/O** — `read()`, `write()`, `create_dir_all()`, `read_dir()` — no need to drop to `std::fs`
-- 📐 **Compile-time markers** — `StrictPath<UserUploads>` vs `StrictPath<SystemConfig>` can't be mixed up
-- ⚡ **Dual modes** — `StrictPath` (detect & reject escapes) or `VirtualPath` (clamp & contain)
-- 🔒 **Thread-safe** — all types are `Send + Sync`; share across threads and async tasks
-- 🤖 **LLM-ready** — doc comments and [context files](https://github.com/DK26/strict-path-rs/blob/main/LLM_CONTEXT_FULL.md) designed for AI agents with function calling
-
-<details>
-<summary><strong>Why the API looks the way it does (design notes for security reviewers and LLM integrators)</strong></summary>
-
-<br>
-
-This crate combines Rust's type system with Python's "one obvious way to do it" philosophy to build an API where **LLMs and humans naturally reach for the correct pattern** — wrong code either doesn't compile, or the compiler tells you exactly what to do instead.
-
-- **No `AsRef<Path>`, no `Deref`** — if `StrictPath` implemented these, anything could call `.join()` on it and build a new path that bypasses boundary validation entirely. That one method on `Path` undoes everything `strict_join()` enforces. The type system makes it unreachable.
-- **`interop_path()` returns `&OsStr`, not `&Path`** — `Path` has `.join()` and `.parent()`, which let you build new unvalidated paths. `OsStr` has none of that — it's a one-way exit to third-party crates with no way to accidentally re-enter path manipulation.
-- **One method per operation** — every operation has exactly one method. An LLM scanning the API can't pick the wrong overload because there isn't one. No aliases, no convenience wrappers, no "which one is the secure version?" Even the weakest model gets it right on the first try.
-- **`#[must_use]` with instructions, not just warnings** — the compiler becomes the documentation. When an LLM generates code and forgets to handle a `strict_join()` result, it doesn't get a generic "unused Result" — it gets a message like *"always handle the Result to detect path traversal attacks"*. The LLM reads the compiler output, self-corrects, and gets it right on the next pass. No docs lookup needed.
-- **Doc comments explain *why*, not just *what*** — every non-trivial function documents the reasoning behind the code, what attack a check prevents, or what invariant it enforces. An LLM working with just the source file can reason about design intent without any external context.
-
-</details>
-
-> 📖 **[Security Methodology →](https://dk26.github.io/strict-path-rs/security_methodology.html)** | 📚 **[Built-in I/O Methods →](https://dk26.github.io/strict-path-rs/best_practices/common_operations.html)** | 📚 **[Anti-Patterns →](https://dk26.github.io/strict-path-rs/anti_patterns.html)**
-
 ## 🎯 When to Use What
 
 **The trigger is the *origin of the path string*.** Is the string something your code produced, or did it come from outside?
@@ -123,7 +86,17 @@ This crate combines Rust's type system with Python's "one obvious way to do it" 
 - Container-like plugins
 - *Any case where you want freedom of operation under complete isolation.*
 
-> 📖 **[Complete Decision Matrix →](https://dk26.github.io/strict-path-rs/best_practices.html)** | 📚 **[More Examples →](https://dk26.github.io/strict-path-rs/examples/overview.html)**
+<details>
+<summary><strong>What <code>strict-path</code> is NOT</strong></summary>
+
+- Not a sandbox or chroot — your process still has whatever filesystem access the OS grants it.
+- Not a replacement for filesystem permissions, SELinux/AppArmor, or `openat2(RESOLVE_BENEATH)`. Compose with those where you have them.
+- Not a URL or shell-argument sanitizer — different injection class, different tool.
+- Not a performance-tuned lexical normalizer — canonicalization touches the disk. If every path is a hardcoded constant and you need nanoseconds, `std::path` is the right tool.
+
+</details>
+
+> 📖 **[Tutorial: Chapter 1 — The Basic Promise →](https://dk26.github.io/strict-path-rs/tutorial/chapter1_basic_promise.html)** · 📖 **[Complete Decision Matrix →](https://dk26.github.io/strict-path-rs/best_practices.html)** · 📚 **[More Examples →](https://dk26.github.io/strict-path-rs/examples/overview.html)**
 
 ---
 
@@ -131,7 +104,7 @@ This crate combines Rust's type system with Python's "one obvious way to do it" 
 
 ### Archive Extraction (Zip Slip Prevention)
 
-`PathBoundary` names the trust anchor explicitly: it holds the canonicalized boundary directory and can be passed by name in function signatures. Every path produced via `strict_join` is proven to stay within it. Naming the boundary in the signature makes the security contract compile-time-visible — the type itself proves the caller provided a vetted anchor.
+Pass `PathBoundary` by name in the function signature — the type itself proves the caller supplied a vetted directory, and every `strict_join` stays inside it.
 
 ```rust
 use strict_path::PathBoundary;
@@ -169,8 +142,6 @@ fn handle_file_request(tenant_id: &str, requested_path: &str) -> std::io::Result
 }
 ```
 
----
-
 ## 🧠 Compile-Time Safety with Markers
 
 `StrictPath<Marker>` enables **domain separation and authorization** at compile time — handing a user-uploaded file to a function that only accepts public assets is a compile error, not a runtime check:
@@ -195,7 +166,29 @@ serve_public_asset(&css);       // ✅ OK — PublicAssets matches
 
 > 📖 **[Complete Marker Tutorial →](https://dk26.github.io/strict-path-rs/tutorial/chapter3_markers.html)** — authorization patterns, permission matrices, `change_marker()` usage.
 
----
+## 🧰 What You Get Beyond Path Validation
+
+- 🛡️ **Built-in I/O** — `read()`, `write()`, `create_dir_all()`, `read_dir()` — no need to drop to `std::fs`
+- 📐 **Compile-time markers** — `StrictPath<UserUploads>` vs `StrictPath<SystemConfig>` can't be mixed up
+- 🔒 **Thread-safe** — all types are `Send + Sync`; share across threads and async tasks
+- 🤖 **LLM-ready** — doc comments and [context files](https://github.com/DK26/strict-path-rs/blob/main/LLM_CONTEXT_FULL.md) designed for AI agents with function calling
+
+<details>
+<summary><strong>Why the API looks the way it does (design notes for security reviewers and LLM integrators)</strong></summary>
+
+<br>
+
+This crate combines Rust's type system with Python's "one obvious way to do it" philosophy to build an API where **LLMs and humans naturally reach for the correct pattern** — wrong code either doesn't compile, or the compiler tells you exactly what to do instead.
+
+- **No `AsRef<Path>`, no `Deref`** — if `StrictPath` implemented these, anything could call `.join()` on it and build a new path that bypasses boundary validation entirely. That one method on `Path` undoes everything `strict_join()` enforces. The type system makes it unreachable.
+- **`interop_path()` returns `&OsStr`, not `&Path`** — `Path` has `.join()` and `.parent()`, which let you build new unvalidated paths. `OsStr` has none of that — it's a one-way exit to third-party crates with no way to accidentally re-enter path manipulation.
+- **One method per operation** — every operation has exactly one method. An LLM scanning the API can't pick the wrong overload because there isn't one. No aliases, no convenience wrappers, no "which one is the secure version?" Even the weakest model gets it right on the first try.
+- **`#[must_use]` with instructions, not just warnings** — the compiler becomes the documentation. When an LLM generates code and forgets to handle a `strict_join()` result, it doesn't get a generic "unused Result" — it gets a message like *"always handle the Result to detect path traversal attacks"*. The LLM reads the compiler output, self-corrects, and gets it right on the next pass. No docs lookup needed.
+- **Doc comments explain *why*, not just *what*** — every non-trivial function documents the reasoning behind the code, what attack a check prevents, or what invariant it enforces. An LLM working with just the source file can reason about design intent without any external context.
+
+</details>
+
+> 📖 **[Security Methodology →](https://dk26.github.io/strict-path-rs/security_methodology.html)** · 📚 **[Built-in I/O Methods →](https://dk26.github.io/strict-path-rs/best_practices/common_operations.html)** · 📚 **[Anti-Patterns →](https://dk26.github.io/strict-path-rs/anti_patterns.html)**
 
 ## 🔒 Zero Idle Dependencies
 
@@ -217,8 +210,6 @@ On Unix the total runtime tree is **2 crates** (`soft-canonicalize` + `proc-cano
 
 </details>
 
----
-
 ## 🔌 Ecosystem Integration
 
 Compose with standard Rust crates for complete solutions:
@@ -233,8 +224,6 @@ Compose with standard Rust crates for complete solutions:
 | **Archives** | ZIP / TAR extraction    | [Guide](https://dk26.github.io/strict-path-rs/examples/archive_extraction.html)             |
 
 > 📚 **[Complete Integration Guide →](https://dk26.github.io/strict-path-rs/ecosystem_integration.html)**
-
----
 
 <details>
 <summary>🤖 <strong>LLM / AI Agent Integration</strong></summary>
@@ -256,8 +245,6 @@ https://github.com/DK26/strict-path-rs/blob/main/LLM_CONTEXT.md
 ```
 
 </details>
-
----
 
 ## 📚 Learn More
 

--- a/strict-path/Cargo.toml
+++ b/strict-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strict-path"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 # Minimum supported Rust version (MSRV)
 rust-version = "1.76"
@@ -29,7 +29,7 @@ app-path = "1.1.2"
 
 # Windows test helper: junctions for symlink tests when admin privileges unavailable
 [target.'cfg(windows)'.dev-dependencies]
-junction = "1.4.2"
+junction = "2.0.0"
 
 # Windows-specific runtime dependencies.
 # `dunce` strips verbatim (`\\?\`) and device (`\\.\`) prefixes correctly —
@@ -38,7 +38,7 @@ junction = "1.4.2"
 # unsafe (reserved names, >260 chars, trailing dots, etc.).
 [target.'cfg(windows)'.dependencies]
 dunce = "1.0"
-junction = { version = "1.4.2", optional = true }
+junction = { version = "2.0.0", optional = true }
 
 [features]
 # Opt-in virtual filesystem support (VirtualRoot, VirtualPath)

--- a/strict-path/src/error/mod.rs
+++ b/strict-path/src/error/mod.rs
@@ -3,6 +3,7 @@
 //! Exposes the crate-wide error enum `StrictPathError`, which captures boundary creation
 //! failures, path resolution errors, and boundary escape attempts. These errors are surfaced
 //! by public constructors and join operations throughout the crate.
+use crate::sanitize::sanitize_untrusted_display_text;
 use std::error::Error;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -14,10 +15,10 @@ const MAX_ERROR_PATH_LEN: usize = 256;
 
 // Internal helper: render error-friendly path display (truncate long values).
 pub(crate) fn truncate_path_display(path: &Path, max_len: usize) -> String {
-    let path_str = path.to_string_lossy();
+    let path_str = sanitize_untrusted_display_text(&path.to_string_lossy());
     let char_count = path_str.chars().count();
     if char_count <= max_len {
-        return path_str.into_owned();
+        return path_str;
     }
     let keep = max_len.saturating_sub(5) / 2;
     let start: String = path_str.chars().take(keep).collect();
@@ -86,9 +87,10 @@ impl fmt::Display for StrictPathError {
                 restriction,
                 source,
             } => {
+                let source_display = sanitize_untrusted_display_text(&source.to_string());
                 write!(
                     f,
-                    "Invalid PathBoundary: '{}' is not a valid boundary directory ({source}). \
+                    "Invalid PathBoundary: '{}' is not a valid boundary directory ({source_display}). \
                      Ensure the path points to an existing directory, or use try_new_create() to auto-create it.",
                     truncate_path_display(restriction, MAX_ERROR_PATH_LEN)
                 )
@@ -108,9 +110,10 @@ impl fmt::Display for StrictPathError {
                 )
             }
             StrictPathError::PathResolutionError { path, source } => {
+                let source_display = sanitize_untrusted_display_text(&source.to_string());
                 write!(
                     f,
-                    "Cannot resolve path: '{}' ({source}). \
+                    "Cannot resolve path: '{}' ({source_display}). \
                      Ensure the target exists and is accessible, or create parent directories first.",
                     truncate_path_display(path, MAX_ERROR_PATH_LEN)
                 )

--- a/strict-path/src/error/tests.rs
+++ b/strict-path/src/error/tests.rs
@@ -10,6 +10,21 @@ fn truncate_path_display_preserves_short_paths() {
 }
 
 #[test]
+fn truncate_path_display_scrubs_log_injection_characters() {
+    let path = Path::new("safe/\nforged\r\x1b[2J\u{0085}\u{202e};tail.txt");
+    let rendered = truncate_path_display(path, 256);
+
+    for forbidden in ['\n', '\r', '\x1b', '\u{0085}', '\u{202e}', ';'] {
+        assert!(
+            !rendered.contains(forbidden),
+            "error path display leaked injection character U+{:04X}: {:?}",
+            forbidden as u32,
+            rendered
+        );
+    }
+}
+
+#[test]
 fn truncate_path_display_inserts_ellipsis_for_long_paths() {
     let segment = "verylongcomponent".repeat(20);
     let path = PathBuf::from(format!("/root/{segment}/tail.txt"));
@@ -51,4 +66,35 @@ fn path_escape_display_mentions_attempt_and_boundary() {
     assert!(rendered.contains("restriction boundary"));
     assert!(rendered.contains("/tmp/attempt"));
     assert!(rendered.contains("/tmp/restriction"));
+}
+
+#[test]
+fn strict_path_error_display_scrubs_untrusted_paths() {
+    let malicious_path = PathBuf::from("/tmp/evil\nFORGED\r\x1b[2J\u{0085}\u{202e};.txt");
+    let cases = [
+        StrictPathError::InvalidRestriction {
+            restriction: malicious_path.clone(),
+            source: io::Error::other("invalid\nSOURCE;"),
+        },
+        StrictPathError::PathResolutionError {
+            path: malicious_path.clone(),
+            source: io::Error::other("resolution\rSOURCE;"),
+        },
+        StrictPathError::PathEscapesBoundary {
+            attempted_path: malicious_path,
+            restriction_boundary: PathBuf::from("/tmp/root\rFORGED"),
+        },
+    ];
+
+    for error in cases {
+        let rendered = error.to_string();
+        for forbidden in ['\n', '\r', '\x1b', '\u{0085}', '\u{202e}', ';'] {
+            assert!(
+                !rendered.contains(forbidden),
+                "StrictPathError display leaked injection character U+{:04X}: {:?}",
+                forbidden as u32,
+                rendered
+            );
+        }
+    }
 }

--- a/strict-path/src/lib.rs
+++ b/strict-path/src/lib.rs
@@ -188,6 +188,7 @@
 
 pub mod error;
 pub mod path;
+mod sanitize;
 pub mod validator;
 
 // Public exports

--- a/strict-path/src/path/virtual_path/display.rs
+++ b/strict-path/src/path/virtual_path/display.rs
@@ -18,7 +18,7 @@ impl<'vpath, Marker> fmt::Display for VirtualPathDisplay<'vpath, Marker> {
         for comp in self.0.virtual_path.components() {
             if let Component::Normal(name) = comp {
                 let s = name.to_string_lossy();
-                parts.push(super::sanitize_display_component(&s));
+                parts.push(crate::sanitize::sanitize_untrusted_display_text(&s));
             }
         }
         if parts.is_empty() {

--- a/strict-path/src/path/virtual_path/mod.rs
+++ b/strict-path/src/path/virtual_path/mod.rs
@@ -36,41 +36,6 @@ pub struct VirtualPath<Marker = ()> {
     pub(crate) virtual_path: PathBuf,
 }
 
-/// Replace dangerous Unicode characters with `_` for safe Display output.
-///
-/// WHY: `virtualpath_display` is the one API surface whose output the crate
-/// actively encourages embedding in user-facing channels (HTTP responses,
-/// logs, terminal prints). The following categories are injection primitives:
-///   - C0 controls (< 0x20): `\n`/`\r` CRLF splitting, `\x1b` ANSI escapes, NUL
-///   - DEL (0x7F): terminal erase behavior on some emulators
-///   - C1 controls (0x80–0x9F): U+0085 NEL acts as newline in HTTP/XML/log parsers
-///   - U+2028/U+2029 (Line/Paragraph Separator): ECMAScript line terminators
-///   - Unicode directional overrides (U+202A–U+202E, U+2066–U+2069, U+200E/U+200F):
-///     visually reverse filename characters, enabling extension-spoofing attacks
-///   - `;` (semicolon): shell command separator — display output may feed a downstream shell reader
-fn sanitize_display_component(component: &str) -> String {
-    let mut out = String::with_capacity(component.len());
-    for ch in component.chars() {
-        let cp = ch as u32;
-        let needs_replace = ch == ';'
-            || cp < 0x20           // C0 controls (NUL through US)
-            || cp == 0x7F          // DEL
-            || (0x80..=0x9F).contains(&cp)  // C1 controls (NEL U+0085, CSI U+009B, etc.)
-            || cp == 0x2028        // LINE SEPARATOR  — ECMAScript line terminator
-            || cp == 0x2029        // PARAGRAPH SEPARATOR — ECMAScript line terminator
-            || cp == 0x200E        // LEFT-TO-RIGHT MARK
-            || cp == 0x200F        // RIGHT-TO-LEFT MARK
-            || (0x202A..=0x202E).contains(&cp)  // LRE, RLE, PDF, LRO, RLO (directional embedding/override)
-            || (0x2066..=0x2069).contains(&cp); // LRI, RLI, FSI, PDI (directional isolate)
-        if needs_replace {
-            out.push('_');
-        } else {
-            out.push(ch);
-        }
-    }
-    out
-}
-
 /// Re-validate a canonicalized path against the boundary after virtual-space manipulation.
 ///
 /// Every virtual mutation (join, parent, with_*) produces a candidate in virtual space that

--- a/strict-path/src/sanitize.rs
+++ b/strict-path/src/sanitize.rs
@@ -1,0 +1,74 @@
+//! Shared sanitization for untrusted strings crossing display/log boundaries.
+
+/// Replace dangerous Unicode characters with `_` for safe Display output.
+///
+/// WHY: strict-path display surfaces are often embedded in user-facing channels
+/// (HTTP responses, logs, terminal prints). The following categories are
+/// injection primitives:
+/// - C0 controls (< 0x20): `\n`/`\r` CRLF splitting, `\x1b` ANSI escapes, NUL
+/// - DEL (0x7F): terminal erase behavior on some emulators
+/// - C1 controls (0x80-0x9F): U+0085 NEL acts as newline in HTTP/XML/log parsers
+/// - U+2028/U+2029 (Line/Paragraph Separator): ECMAScript line terminators
+/// - Unicode directional overrides (U+202A-U+202E, U+2066-U+2069, U+200E/U+200F):
+///   visually reverse filename characters, enabling extension-spoofing attacks
+/// - `;` (semicolon): shell command separator; display output may feed downstream shell readers
+#[inline]
+pub(crate) fn sanitize_untrusted_display_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        let cp = ch as u32;
+        let needs_replace = ch == ';'
+            || cp < 0x20
+            || cp == 0x7F
+            || (0x80..=0x9F).contains(&cp)
+            || cp == 0x2028
+            || cp == 0x2029
+            || cp == 0x200E
+            || cp == 0x200F
+            || (0x202A..=0x202E).contains(&cp)
+            || (0x2066..=0x2069).contains(&cp);
+        if needs_replace {
+            out.push('_');
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_untrusted_display_text;
+
+    #[test]
+    fn preserves_plain_text() {
+        assert_eq!(
+            sanitize_untrusted_display_text("safe/path-_.txt"),
+            "safe/path-_.txt"
+        );
+    }
+
+    #[test]
+    fn scrubs_each_injection_character_class() {
+        let dangerous = [
+            '\n',       // C0 newline
+            '\r',       // C0 carriage return
+            '\x1b',     // C0 ANSI escape
+            '\x7f',     // DEL
+            '\u{0085}', // C1 NEL
+            '\u{009b}', // C1 CSI
+            '\u{2028}', // line separator
+            '\u{2029}', // paragraph separator
+            '\u{200e}', // left-to-right mark
+            '\u{200f}', // right-to-left mark
+            '\u{202e}', // right-to-left override
+            '\u{2066}', // left-to-right isolate
+            ';',        // shell separator
+        ];
+
+        let input: String = dangerous.iter().collect();
+        let expected = "_".repeat(dangerous.len());
+
+        assert_eq!(sanitize_untrusted_display_text(&input), expected);
+    }
+}


### PR DESCRIPTION
# Release v0.2.3

## Summary

Patch release. One security-relevant fix to `StrictPathError` display output, a
batch of README clarity improvements, and a Windows-only dependency bump.

---

## Changes

### Fixed

**Error display sanitizer** (`strict-path/src/error/mod.rs`, `src/sanitize.rs`)

`StrictPathError`'s `Display` impl now scrubs the same injection characters that
`virtualpath_display()` already sanitized, before they appear in error messages.
Affected characters: C0/C1 controls, DEL, U+2028/U+2029 (ECMAScript line
terminators), Unicode directional overrides/marks (U+202A–U+202E, U+2066–U+2069,
U+200E/U+200F), and `;`.

Without this fix, a crafted path containing ANSI escape sequences, CRLF bytes,
or bidirectional override characters could survive into error messages and cause
log-line spoofing, terminal injection, or header splitting in callers that log or
forward `StrictPathError` strings.

The sanitizer logic is now shared via a new `crate::sanitize` module, so the
same scrubbing rules apply consistently across both display surfaces.

Relevant commits: `390ce24`, `cda1837`

---

### Documentation

Four README passes improving:

- How canonicalization and boundary checks interact (readers were conflating
  "resolves symlinks" with "blocks all symlink attacks").
- What `PathBoundary` guarantees vs. what it deliberately does not guarantee
  (TOCTOU, post-validation filesystem changes).
- Clearer framing of the `StrictPath` / `VirtualPath` split for new readers.

Commits: `3c2f578`, `5058bce`, `87f9859`, `fa2ec03`

---

### Dependencies

**`junction` 1.4.2 → 2.0.0** (Windows-only; optional runtime + test dep)

Upstream change: `junction::get_target()` no longer requires the destination
directory to exist. `strict-path` calls `junction::create()` only, so there is
no behavior change in this crate.

---

## Checklist

- [x] `cargo check -p strict-path --all-features` passes
- [x] `CHANGELOG.md` updated
- [x] Version bumped to `0.2.3` in `strict-path/Cargo.toml`
